### PR TITLE
feat(quiz): Provide color-coded feedback for correct and incorrect answers

### DIFF
--- a/.idea/AndroidProjectSystem.xml
+++ b/.idea/AndroidProjectSystem.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AndroidProjectSystem">
+    <option name="providerId" value="com.android.tools.idea.GradleProjectSystem" />
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -2,23 +2,58 @@
 <project version="4">
   <component name="deploymentTargetSelector">
     <selectionStates>
-      <SelectionState runConfigName="Unnamed">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
       <SelectionState runConfigName="app">
-        <option name="selectionMode" value="DROPDOWN" />
-      </SelectionState>
-      <SelectionState runConfigName="MainActivity (1)">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
       <SelectionState runConfigName="MainActivity (2)">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-03-26T16:43:40.844751100Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Admin\.android\avd\Pixel_3a_API_34_extension_level_7_x86_64.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
+      </SelectionState>
+      <SelectionState runConfigName="Sight Reading App.Sight_Reading_App.app">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
+      <SelectionState runConfigName="MainActivity (1)">
+        <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-03-26T16:41:14.234529500Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Admin\.android\avd\Pixel_Fold_API_Baklava.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
+      </SelectionState>
+      <SelectionState runConfigName="MainActivity (3)">
+        <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-03-26T17:12:59.906847100Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Admin\.android\avd\Pixel_3a_API_34_extension_level_7_x86_64.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
       <SelectionState runConfigName="ProfileActivity">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
-      <SelectionState runConfigName="ProfileActivity (1)">
+      <SelectionState runConfigName="MainActivity">
         <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-03-27T11:43:39.977661200Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\Admin\.android\avd\Pixel_Fold_API_Baklava.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
       </SelectionState>
     </selectionStates>
   </component>

--- a/.idea/easycode.ignore
+++ b/.idea/easycode.ignore
@@ -1,0 +1,13 @@
+.idea
+.vscode
+node_modules/
+dist/
+vendor/
+cache/
+.*/
+*.min.*
+*.test.*
+*.spec.*
+*.bundle.*
+*.bundle-min.*
+*.log

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -40,6 +40,9 @@
     <inspection_tool class="PreviewMultipleParameterProviders" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
     </inspection_tool>
+    <inspection_tool class="PreviewParameterProviderOnFirstParameter" enabled="true" level="ERROR" enabled_by_default="true">
+      <option name="composableFile" value="true" />
+    </inspection_tool>
     <inspection_tool class="PreviewPickerAnnotation" enabled="true" level="ERROR" enabled_by_default="true">
       <option name="composableFile" value="true" />
     </inspection_tool>

--- a/app/src/main/java/com/example/sightreadingapp/ui/screens/QuizScreen.kt
+++ b/app/src/main/java/com/example/sightreadingapp/ui/screens/QuizScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -25,6 +26,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.example.sightreadingapp.models.Accidentals
@@ -101,7 +103,8 @@ fun QuizScreen(
     var currentQuestionIndex by remember { mutableIntStateOf(0) }
     var hasAttempted by remember { mutableStateOf(false) }
     var resultMessage by remember { mutableStateOf("") }
-    val coroutineScope = rememberCoroutineScope()
+    val coroutineScope = rememberCoroutineScope() // added to track the selected answer for color feedback
+    var selectedAnswer by remember { mutableStateOf<String?>(null) }
 
     // Create a list of questions dynamically
     val questions = remember { mutableStateListOf<Question>() }
@@ -155,6 +158,7 @@ fun QuizScreen(
                     onClick = {
                         if (!hasAttempted) {
                             hasAttempted = true
+                            selectedAnswer = option // record user's selection (added for answer color feedback)
                             if (option == currentQuestion.correctAnswer) {
                                 resultMessage = "Correct!"
                                 updateScore(10)
@@ -163,6 +167,7 @@ fun QuizScreen(
                                     currentQuestionIndex++
                                     hasAttempted = false
                                     resultMessage = ""
+                                    selectedAnswer = null // reset the answer selection
                                 }
                             } else {
                                 resultMessage = "Wrong! Correct answer: ${currentQuestion.correctAnswer}"
@@ -171,10 +176,19 @@ fun QuizScreen(
                                     currentQuestionIndex++
                                     hasAttempted = false
                                     resultMessage = ""
+                                    selectedAnswer = null // reset the answer selection
                                 }
                             }
                         }
                     },
+                    colors = ButtonDefaults.buttonColors( // leaves button background color based on the answer selection
+                        containerColor = when {
+                            selectedAnswer == null -> ButtonDefaults.buttonColors().containerColor // color is not selected yet, so use the default color
+                            selectedAnswer == option && option == currentQuestion.correctAnswer -> Color.Green // if this button is selected and the answer is correct, show green
+                            selectedAnswer == option && option != currentQuestion.correctAnswer -> Color.Red  // if this button is selected and the answer is correct, show red
+                            else -> ButtonDefaults.buttonColors().containerColor // else using the default color
+                        }
+                    ),
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(vertical = 4.dp)


### PR DESCRIPTION
- Introduces a **selectedAnswer** state in **QuizScreen** to track which answer the user selects.
- Conditionally sets the button background color to green for correct answers and red for incorrect answers, giving immediate visual feedback.
- Resets the selected answer and feedback message after a short delay, before moving on to the next question.